### PR TITLE
don't update deployment status environment when empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          id=$(github deployment create --autoMerge=false --productionEnvironment=false --environment staging $GITHUB_REF)
+          id=$(github deployment create --productionEnvironment=false --environment staging $GITHUB_REF)
           github deployment_status create $id in_progress
           echo "##[set-output name=deployment_id;]$id"
       - env:
@@ -111,7 +111,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          id=$(github deployment create --autoMerge=false $GITHUB_REF)
+          id=$(github deployment create $GITHUB_REF)
           echo "##[set-output name=deployment_id;]$id"
       # #-----------------------------8<----------------------------------------
       # # here: some job(s) to add for example a deploy button/process

--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -121,7 +121,7 @@ func init() {
 
 	deployment.AddCommand(deploymentCreateCmd)
 	deploymentCreateCmd.PersistentFlags().StringP("task", "t", "deploy", "Specifies a task to execute (e.g., deploy or deploy:migrations).")
-	deploymentCreateCmd.PersistentFlags().BoolP("autoMerge", "a", true, "Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch.")
+	deploymentCreateCmd.PersistentFlags().BoolP("autoMerge", "a", false, "Attempts to automatically merge the default branch into the requested ref, if it's behind the default branch.")
 	deploymentCreateCmd.PersistentFlags().StringSliceP("requiredContexts", "c", []string{}, "The status contexts to verify against commit status checks. If you omit this parameter, GitHub verifies all unique contexts before creating a deployment. To bypass checking entirely, pass an empty array. Defaults to all unique contexts.")
 	deploymentCreateCmd.PersistentFlags().StringP("payload", "p", "", "JSON payload with extra information about the deployment.")
 	deploymentCreateCmd.PersistentFlags().StringP("environment", "e", "production", "Name for the target deployment environment (e.g., production, staging, qa).")

--- a/cmd/deployment_status.go
+++ b/cmd/deployment_status.go
@@ -125,6 +125,9 @@ var deploymentStatusCreateCmd = &cobra.Command{
 		if err != nil {
 			log.Fatal(err)
 		}
+		if len(*deploymentStatusRequest.Environment) == 0 {
+			deploymentStatusRequest.Environment = nil
+		}
 
 		deploymentStatus, _, err := client.Repositories.CreateDeploymentStatus(ctx, owner, repository, deploymentID, &deploymentStatusRequest)
 		if err != nil {


### PR DESCRIPTION
BREAKING CHANGE: auto merge is now false by default on deployment