### PR TITLE
chore(cd): remove now useless github user env var

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         # https://help.github.com/en/articles/virtual-environments-for-github-actions#token-permissions
-        export GITHUB_USER=${GITHUB_ACTOR}
         hub release edit \
           "${TAG_NAME}" \
           -m "" \


### PR DESCRIPTION
Since [hub 2.12.4](https://github.com/github/hub/releases/tag/v2.12.4) this is now also infered from GITHUB_REPOSITORY 😉